### PR TITLE
socket: clear interval instead of timeout

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -372,7 +372,7 @@ class Socket extends EventEmitter {
 
   stop() {
     if (this.timer != null) {
-      clearTimeout(this.timer);
+      clearInterval(this.timer);
       this.timer = null;
     }
   }


### PR DESCRIPTION
`this.timer` is set with `setInterval()` so should be cleared with `clearInterval()`