### PR TITLE
Minimal namespace support

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -24,6 +24,7 @@ class Socket extends EventEmitter {
     this.ws = null;
     this.protocol = '';
     this.url = 'ws://127.0.0.1:80/socket.io/?transport=websocket';
+    this.path = '/socket.io';
     this.ssl = false;
     this.host = '127.0.0.1';
     this.port = 80;
@@ -66,10 +67,12 @@ class Socket extends EventEmitter {
     assert(socket.remoteAddress);
     assert(socket.remotePort != null);
     assert(ws);
+    assert(typeof req.url === 'string');
 
     let proto = 'ws';
     let host = socket.remoteAddress;
     let port = socket.remotePort;
+    const [path, qs='transport=websocket'] = req.url.split('/?');
 
     if (socket.encrypted)
       proto = 'wss';
@@ -82,7 +85,8 @@ class Socket extends EventEmitter {
 
     this.server = server;
     this.binary = req.url.indexOf('b64=1') === -1;
-    this.url = `${proto}://${host}:${port}/socket.io/?transport=websocket`;
+    this.path = path;
+    this.url = `${proto}://${host}:${port}${path}/?${qs}`;
     this.ssl = proto === 'wss';
     this.host = socket.remoteAddress;
     this.port = socket.remotePort;
@@ -94,7 +98,7 @@ class Socket extends EventEmitter {
     return this;
   }
 
-  connect(port, host, ssl, protocols) {
+  connect(port, host, ssl, protocols, path = '/socket.io') {
     assert(!this.ws, 'Cannot connect twice.');
 
     if (typeof port === 'string') {
@@ -119,11 +123,11 @@ class Socket extends EventEmitter {
     if (host.indexOf(':') !== -1 && host[0] !== '[')
       hostname = `[${host}]`;
 
-    const path = '/socket.io';
     const qs = '?transport=websocket';
     const url = `${proto}://${hostname}:${port}${path}/${qs}`;
 
     this.binary = true;
+    this.path = path;
     this.url = url;
     this.ssl = ssl;
     this.host = host;
@@ -903,8 +907,8 @@ class Socket extends EventEmitter {
     return new this().accept(server, req, socket, ws);
   }
 
-  static connect(port, host, ssl, protocols) {
-    return new this().connect(port, host, ssl, protocols);
+  static connect(port, host, ssl, protocols, path) {
+    return new this().connect(port, host, ssl, protocols, path);
   }
 }
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -72,7 +72,14 @@ class Socket extends EventEmitter {
     let proto = 'ws';
     let host = socket.remoteAddress;
     let port = socket.remotePort;
-    const [path, qs='transport=websocket'] = req.url.split('/?');
+    const qs = '/?transport=websocket';
+    const qsIndex = req.url.indexOf(qs);
+
+    const path = req.url.slice(qsIndex);
+    assert(
+      path.indexOf('/?') !== -1,
+      'path should not have custom query string'
+    );
 
     if (socket.encrypted)
       proto = 'wss';
@@ -86,7 +93,7 @@ class Socket extends EventEmitter {
     this.server = server;
     this.binary = req.url.indexOf('b64=1') === -1;
     this.path = path;
-    this.url = `${proto}://${host}:${port}${path}/?${qs}`;
+    this.url = `${proto}://${host}:${port}${path}${qs}`;
     this.ssl = proto === 'wss';
     this.host = socket.remoteAddress;
     this.port = socket.remotePort;

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -24,7 +24,7 @@ class Socket extends EventEmitter {
     this.ws = null;
     this.protocol = '';
     this.url = 'ws://127.0.0.1:80/socket.io/?transport=websocket';
-    this.path = '/socket.io';
+    this.namespace = 'socket.io';
     this.ssl = false;
     this.host = '127.0.0.1';
     this.port = 80;
@@ -75,10 +75,10 @@ class Socket extends EventEmitter {
     const qs = '/?transport=websocket';
     const qsIndex = req.url.indexOf(qs);
 
-    const path = req.url.slice(qsIndex);
+    const namespace = req.url.slice(qsIndex);
     assert(
-      path.indexOf('/?') !== -1,
-      'path should not have custom query string'
+      namespace.indexOf('/?') !== -1,
+      'namespace should not have custom query string'
     );
 
     if (socket.encrypted)
@@ -92,8 +92,8 @@ class Socket extends EventEmitter {
 
     this.server = server;
     this.binary = req.url.indexOf('b64=1') === -1;
-    this.path = path;
-    this.url = `${proto}://${host}:${port}${path}${qs}`;
+    this.namespace = namespace;
+    this.url = `${proto}://${host}:${port}/${namespace}${qs}`;
     this.ssl = proto === 'wss';
     this.host = socket.remoteAddress;
     this.port = socket.remotePort;
@@ -105,7 +105,7 @@ class Socket extends EventEmitter {
     return this;
   }
 
-  connect(port, host, ssl, protocols, path = '/socket.io') {
+  connect(port, host, ssl, protocols, namespace = 'socket.io') {
     assert(!this.ws, 'Cannot connect twice.');
 
     if (typeof port === 'string') {
@@ -131,10 +131,10 @@ class Socket extends EventEmitter {
       hostname = `[${host}]`;
 
     const qs = '?transport=websocket';
-    const url = `${proto}://${hostname}:${port}${path}/${qs}`;
+    const url = `${proto}://${hostname}:${port}/${namespace}/${qs}`;
 
     this.binary = true;
-    this.path = path;
+    this.namespace = namespace;
     this.url = url;
     this.ssl = ssl;
     this.host = host;
@@ -914,8 +914,8 @@ class Socket extends EventEmitter {
     return new this().accept(server, req, socket, ws);
   }
 
-  static connect(port, host, ssl, protocols, path) {
-    return new this().connect(port, host, ssl, protocols, path);
+  static connect(port, host, ssl, protocols, namespace) {
+    return new this().connect(port, host, ssl, protocols, namespace);
   }
 }
 


### PR DESCRIPTION
This is a minimal implementation of namespaces in bsock. Socket connections can indicate the namespace they want to interact with by passing the `namespace` argument during handshake. This can overwrite the default `socket.io` namespace currently written into the path. 