### PR TITLE
fixed unhook

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -864,7 +864,6 @@ class Socket extends EventEmitter {
 
   unhook(event) {
     enforce(typeof event === 'string', 'event', 'string');
-    enforce(typeof handler === 'function', 'handler', 'function');
     assert(!blacklist.hasOwnProperty(event), 'Blacklisted event.');
     this.hooks.delete(event);
   }


### PR DESCRIPTION
Unhook does not have a `handler` param which is why the second `enforce` always fails. Removing the line fixes the issue and appears safe.
