### PR TITLE
socket: don't queue events on destroyed sockets.

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -875,6 +875,9 @@ class Socket extends EventEmitter {
     enforce(args.length > 0, 'event', 'string');
     enforce(typeof args[0] === 'string', 'event', 'string');
 
+    if (this.destroyed)
+      return Promise.reject(new Error('Socket destroyed.'));
+
     const id = this.sequence;
 
     this.sequence += 1;


### PR DESCRIPTION
Sockets queue in the job queue when we want to wait for the response. This applies both to the closed socket (not destryoed) - which may reconnect and open connection. For both of these there's an interval running to check for timeouts for these jobs.

Situation is different when the socket destroyed. Destroyed socket may never reconnect nor should be reused. Timeout loop is also closed, so it should never queue the events but instead throw errors.